### PR TITLE
avoid breaking bootup if lvextend has nothing to do

### DIFF
--- a/scripts/live/init/occupy-space.sh
+++ b/scripts/live/init/occupy-space.sh
@@ -35,10 +35,13 @@ echo "** Extending disk space..."
         echo MSG extending the lvm volume group...
         vgextend $LVM_VG ${device}4
     fi
-    echo MSG resizing lvm logical volume...
-    lvextend -l+100%FREE /dev/$LVM_VG/ROOT
-    echo MSG resizing filesystem...
-    resize2fs /dev/$LVM_VG/ROOT
+
+    if [ "x$(vgs -o vg_free --noheadings --nosuffix $LVM_VG | tr -d [:blank:])" != "x0" ]; then
+       echo MSG resizing lvm logical volume...
+       lvextend -l+100%FREE /dev/$LVM_VG/ROOT
+       echo MSG resizing filesystem...
+       resize2fs /dev/$LVM_VG/ROOT
+    fi
 
     echo RETURN 0
 } | filter_quiet


### PR DESCRIPTION
Currently in ```occupy-space.sh```, ```lvextend``` is getting invoked even if the volume group has no free space available.

In this special case, ```lvextend``` just prints a message that the LV size has not been changed and exits non-zero - the boot sequence gets interrupted by this and fails.

While this behavior is clearly caused by an user-error - not having run ```truncate``` to increase the image size before using it with QEMU - it might be more convenient to not fail here and have the boot sequence succeed.
Finally it's a user decision if he want to stick with the original image file or expands it and imho should not cause any abnormal termination in the boot sequence.