### PR TITLE
Allow stripping no quiet kernel parameter

### DIFF
--- a/debootstick
+++ b/debootstick
@@ -26,6 +26,7 @@ root_password_on_first_boot=0
 config_grub_on_serial_line=0
 system_type="live"
 kernel_bootargs=""
+kernel_strip_quiet_from_cmdline=0
 config_hostname=""
 while [ $# != 0 ] 
 do
@@ -48,6 +49,10 @@ do
         --config-kernel-bootargs)
             kernel_bootargs="$2"
             shift 2
+        ;;
+        --config-kernel-strip-quiet-from-cmdline)
+            kernel_strip_quiet_from_cmdline=1
+            shift
         ;;
         --config-root-password-ask)
             root_password_request="ASK"
@@ -221,6 +226,7 @@ with mount -o bind /etc/resolv.conf $PWD/etc/resolv.conf; do
                 config_grub_on_serial_line=$config_grub_on_serial_line  \
                 kernel_package="\"$kernel_package\""    \
                 kernel_bootargs="\"$kernel_bootargs\"" \
+                kernel_strip_quiet_from_cmdline="\"$kernel_strip_quiet_from_cmdline\"" \
                 config_hostname="\"$config_hostname\"" \
                 target_arch="$target_arch"
 done

--- a/debootstick.8
+++ b/debootstick.8
@@ -69,6 +69,9 @@ Specify the hostname the embedded system will have.
 Specify boot arguments to be added to the kernel. (You may specify several arguments, e.g.
 \fB\-\-config\-kernel\-bootargs \(dqconsole=ttyS0 acpi=off\(dq\fP.)
 .TP
+.B \-\-config\-kernel\-strip\-quiet\-from\-cmdline
+Removes the "quiet" option from kernel cmdline parameters if present.
+.TP
 .B \-\-config\-root\-password\-ask
 Prompt for the root password of the embedded system and set it accordingly.
 .TP

--- a/scripts/create-image/chrooted-customization-draft.sh
+++ b/scripts/create-image/chrooted-customization-draft.sh
@@ -114,6 +114,12 @@ sed -i -e "s/GRUB_CMDLINE_LINUX=.*/GRUB_CMDLINE_LINUX=\"$GRUB_CMDLINE_LINUX\"/" 
        -e "s/^GRUB_HIDDEN/#GRUB_HIDDEN/g" \
         /etc/default/grub
 
+# remove the "quiet" option from kernel boot cmdline
+# if instructed by kernel_strip_quiet_from_cmdline=1.
+if [ "x${kernel_strip_quiet_from_cmdline}" = "x1" ]; then
+   sed -i -e '/^GRUB_CMDLINE_LINUX/s/\s*quiet//g' ./etc/default/grub
+fi
+
 # for text console in kvm
 if [ "$debug" = "1" ]
 then


### PR DESCRIPTION
Perhaps this might be also useful to others. I've added a ```--config-kernel-strip-quiet-from-cmdline``` parameter that removes the "quiet" parameter from the kernel boot arguments, if it exists.

Actually it modifies ```/etc/default/grub``` in the chroot environment and removes "quiet" from the "GRUB_CMDLINE_LINUX"-beginning lines, it is present there.