### PR TITLE
Do not remove /var/cache/debconf from chroot

### DIFF
--- a/scripts/create-image/common/finalize
+++ b/scripts/create-image/common/finalize
@@ -7,7 +7,7 @@ finalize_fs()
 
     # clean up
     rm -rf proc/* sys/* dev/* tmp/* \
-            $(find run -type f) var/cache/* var/lock
+            $(find run -type f) $(ls -1d /var/cache/* | grep -v 'debconf$') var/lock            
 
     # install debootstick init hook on getty command
     getty_command="$(realpath --relative-to . "$(readlink -f sbin/getty)")"


### PR DESCRIPTION
This change causes debootstick to preserve the `/var/cache/debconf` directory in the chroot.  This is necessary in order for the Ubiquity installer to launch upon booting of the live system.  Without this change a python stack trace with the message "debian-installer/locale doesn't exist" is emitted to the log and the application crashes.

This fix was described by the project author in https://github.com/drakkar-lig/debootstick/issues/29.

## Testing Done
1. Installed patched version of debootstick with this change on local machine
2. generated ISO
3. Booted iso and verified that ubiquity starts on first boot without crashing.

