### PR TITLE
Makefile uninstall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,6 @@ install:
 	chown root:root $(DESTDIR)/usr/sbin/debootstick
 	chmod 0755 $(DESTDIR)/usr/sbin/debootstick
 
+uninstall:
+	rm -Rf $(DSDIR)
+	rm $(DESTDIR)/usr/sbin/debootstick

--- a/scripts/create-image/common/finalize
+++ b/scripts/create-image/common/finalize
@@ -7,7 +7,7 @@ finalize_fs()
 
     # clean up
     rm -rf proc/* sys/* dev/* tmp/* \
-            $(find run -type f) var/cache/* var/lock
+            $(find run -type f) $(ls -1d /var/cache/* | grep -v 'debconf$') var/lock            
 
     # install debootstick init hook on getty command
     getty_command="$(realpath --relative-to . "$(readlink -f sbin/getty)")"

--- a/scripts/create-image/common/finalize
+++ b/scripts/create-image/common/finalize
@@ -7,7 +7,7 @@ finalize_fs()
 
     # clean up
     rm -rf proc/* sys/* dev/* tmp/* \
-            $(find run -type f) $(ls -1d /var/cache/* | grep -v 'debconf$') var/lock            
+            $(find run -type f) var/cache/* var/lock
 
     # install debootstick init hook on getty command
     getty_command="$(realpath --relative-to . "$(readlink -f sbin/getty)")"


### PR DESCRIPTION
This change adds a target to uninstall debootstick.  Useful when comparing Debian packaged version with a local build.

## Testing Done
1. Run `make uninstall`, verify that files are removed
2. Run `apt install debootstick`, verify that install proceeds succesfully


