### PR TITLE
Update tool.sh to add support to NVMe devices

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+debootstick (2.5-flplv) unstable; urgency=medium
+
+  * Added support to migrating to NVMe devices
+  
+  -- Felipe Lavratti <>  Mon, 22 Dez 2020 00:32:25 -0003
+
 debootstick (2.5) unstable; urgency=medium
 
   * Validate support for Raspberry Pi 4

--- a/scripts/live/init/tools.sh
+++ b/scripts/live/init/tools.sh
@@ -89,7 +89,7 @@ get_higher_capacity_devices()
     threshold=$1
     cat /proc/partitions | while read major minor size name
     do
-        if [ "$major" = "8" ]
+        if [ "$major" = "8" ] || [ "$major" = "259" ]
         then
             if [ "$((minor % 16))" -eq 0 -a $((size*1024)) -gt $threshold ]
             then


### PR DESCRIPTION
This adds support to NVMe devices to the init scripts, allowing the embedded distro to be moved to a NVMe drive. Tested in a 2020's Dell Optiplex 3080.