### PR TITLE
Add support for Debian Trixie

### DIFF
--- a/scripts/create-image/cmdline
+++ b/scripts/create-image/cmdline
@@ -11,10 +11,11 @@ describe_os_support()
     cat << EOF
 This version of debootstick was tested successfully with the following kinds of
 chroot-environments:
-* OS for Raspberry Pi:
+* 32-bit arm Raspberry Pi:
     - Raspberry Pi OS (formerly "rasbian") bullseye
-* OS for 32 or 64 bit PCs:
-    - Debian 12 (bookworm) as of october 20, 2022
+* 64-bit amd64 systems:
+    - Debian 13 (trixie) as of September 2nd, 2025
+    - Debian 12 (bookworm)
     - Debian 11 (bullseye)
     - Ubuntu 22.10 (kinetic)
     - Ubuntu 22.04 LTS (jammy)


### PR DESCRIPTION

I'm unaware of any code changes that need to be made for Trixie support other than updating the message output of the program.  I have successfully built and run a Trixie-based debootstick environment myself and did not encounter any issues.  Happy to update the PR if there are additional items required for Trixie compat that I may have missed.

NOTE: I made some minor tweaks to the message based on https://github.com/drakkar-lig/debootstick/issues/44#issuecomment-2031215776, but happy to use the existing style if preferred.  I opted to include the CPU arch labels (`arm`, `amd64`) in addition to the word size.